### PR TITLE
:pushpin: Set libhal version to ^3.0.0

### DIFF
--- a/.github/workflows/4.0.0-alpha.2.yml
+++ b/.github/workflows/4.0.0-alpha.2.yml
@@ -1,0 +1,11 @@
+name: 🚀 4.0.0-alpha.2
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy_all.yml@5.x.y
+    with:
+      version: 4.0.0-alpha.2
+    secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -63,7 +63,7 @@ class libhal_util_conan(ConanFile):
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
-        self.requires("libhal/3.0.0-alpha.2", transitive_headers=True)
+        self.requires("libhal/3.0.0-alpha.3", transitive_headers=True)
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
Allows libhal alpha version to be used and anything 3.0.0 compatible.