### PR TITLE
:technologist: Add .clangd file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/Release

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,6 @@ required_conan_version = ">=2.0.14"
 class libhal_util_conan(ConanFile):
     name = "libhal-util"
     license = "Apache-2.0"
-    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-util"
     description = ("A collection of interfaces and abstractions for embedded "
                    "peripherals and devices using modern C++")


### PR DESCRIPTION
Enable developers to use the clangd LSP with their text editor of choice such as VSCode, NVIM, Zed and many others support clangd.

Users should run `conan build .` to generate the necessary files for `clangd` to work.