### PR TITLE
:arrow_up: upgrade libhal-cmake-util/4.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(libhal-util LANGUAGES CXX)
 
-libhal_test_and_make_library(
-  LIBRARY_NAME libhal-util
-
-  SOURCES
-  src/steady_clock.cpp
-  src/streams.cpp
-
-  TEST_SOURCES
+set(TEST_SOURCES_LIST
   tests/as_bytes.test.cpp
   tests/can.test.cpp
   tests/bit.test.cpp
@@ -45,6 +38,32 @@ libhal_test_and_make_library(
   tests/timeout.test.cpp
   tests/units.test.cpp
   tests/main.test.cpp
+)
+
+set(SOURCES_LIST
+  src/steady_clock.cpp
+  src/streams.cpp
+)
+
+if(NOT ${CMAKE_CROSSCOMPILING})
+  libhal_unit_test(
+    SOURCES
+    ${SOURCES_LIST}
+    ${TEST_SOURCES_LIST}
+
+    PACKAGES
+    libhal
+
+    LINK_LIBRARIES
+    libhal::libhal
+  )
+endif()
+
+libhal_make_library(
+  LIBRARY_NAME libhal-util
+
+  SOURCES
+  ${SOURCES_LIST}
 
   PACKAGES
   libhal

--- a/conanfile.py
+++ b/conanfile.py
@@ -58,7 +58,7 @@ class libhal_util_conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires("libhal-cmake-util/3.0.1")
+        self.tool_requires("libhal-cmake-util/[^4.1.0]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):


### PR DESCRIPTION
This change requires libhal-util to NOT use the full `libhal_make_and_test_library` which attempts to include `libha-util` during the build.