### PR TITLE
:sparkles: Add compile time bit_value::insert

### DIFF
--- a/.github/workflows/4.1.0.yml
+++ b/.github/workflows/4.1.0.yml
@@ -1,0 +1,11 @@
+name: 🚀 4.1.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy_all.yml@5.x.y
+    with:
+      version: 4.1.0
+    secrets: inherit

--- a/include/libhal-util/bit.hpp
+++ b/include/libhal-util/bit.hpp
@@ -264,7 +264,7 @@ constexpr auto bit_extract(bit_mask p_field,
   return static_cast<T>(masked);
 }
 
-template<std::unsigned_integral T>
+template<std::unsigned_integral T = std::uint32_t>
 class bit_value
 {
 public:
@@ -359,6 +359,22 @@ public:
   }
 
   constexpr auto& insert(bit_mask p_field, std::unsigned_integral auto p_value)
+  {
+    // AND value with mask to remove any bits beyond the specified width.
+    // Shift masked value into bit position and OR with target value.
+    auto shifted_field = static_cast<T>(p_value) << p_field.position;
+    auto new_value = shifted_field & p_field.value<T>();
+
+    // Clear width's number of bits in the target value at the bit position
+    // specified.
+    m_value = m_value & ~p_field.value<T>();
+    m_value = m_value | static_cast<T>(new_value);
+
+    return *this;
+  }
+
+  template<bit_mask p_field, std::unsigned_integral auto p_value>
+  constexpr auto& insert()
   {
     // AND value with mask to remove any bits beyond the specified width.
     // Shift masked value into bit position and OR with target value.

--- a/tests/bit.test.cpp
+++ b/tests/bit.test.cpp
@@ -27,6 +27,7 @@ void bit_test()
     constexpr auto enable_bit = bit_mask::from<1>();
     constexpr auto high_power_mode = bit_mask::from<15>();
     constexpr auto clock_divider = bit_mask::from<20, 23>();
+    constexpr auto phase_delay = bit_mask::from<24, 27>();
     constexpr auto extractor_mask = bit_mask::from<16, 23>();
     constexpr auto single_bit_mask = bit_mask::from<1>();
 
@@ -34,14 +35,15 @@ void bit_test()
     bit_modify(control_register)
       .set<enable_bit>()
       .clear<high_power_mode>()
-      .insert<clock_divider>(0xAU);
+      .insert<clock_divider>(0xAU)
+      .insert<phase_delay, 0x3U>();
     auto extracted = bit_extract<extractor_mask>(control_register);
     auto probed = bit_extract<single_bit_mask>(control_register);
     auto probed_inline =
       bit_extract<bit_mask{ .position = 15, .width = 1 }>(control_register);
 
     // Verify
-    expect(that % 0x00A1'0002 == control_register);
+    expect(that % 0x03A1'0002 == control_register);
     expect(that % 0xA1 == extracted);
     expect(that % 1 == probed);
     expect(that % 0 == probed_inline);


### PR DESCRIPTION
Add bit_value::insert API that can take a bit field and value as template arguments resulting in a completely compile time value.

Set bit_value template to default std::uint32_t for ease of use.