### PR TITLE
:sparkles: Make nibble & byte masks ranged

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,4 +5,3 @@ If:
 Else:
   CompileFlags:
     CompilationDatabase: .
-


### PR DESCRIPTION
`nibble_m` and `byte_m` have a second parameter that creates a range. For example `nibble_m<1,4>` is a mask that covers the area from nibble 1 to nibble 4 or bits 4 to 16. Same logic for `byte_m`.