### PR TITLE
:arrow_up: upgrade to libhal 4.5.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -62,7 +62,7 @@ class libhal_util_conan(ConanFile):
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
-        self.requires("libhal/[^4.0.0]", transitive_headers=True)
+        self.requires("libhal/[^4.4.0]", transitive_headers=True)
 
     def layout(self):
         cmake_layout(self)

--- a/include/libhal-util/atomic_spin_lock.hpp
+++ b/include/libhal-util/atomic_spin_lock.hpp
@@ -1,0 +1,89 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+#include <libhal/lock.hpp>
+#include <libhal/steady_clock.hpp>
+
+namespace hal::soft {
+/**
+ * @brief Atomic spin lock that implements hal::pollable_lock
+ *
+ * This lock provides an operating system agnostic lock that works on any
+ * processor that support lock-free atomic boolean operations, which should be
+ * almost all systems.
+ *
+ * This lock will perform a spin lock until it acquires a lock. Using such a
+ * lock on a properly multithreaded system is inefficient as it does not have
+ * the capability to notify the system that a thread is currently waiting for
+ * the lock to be made available.
+ *
+ * This lock is useful as a default lock for platform libraries, in order to
+ * ensure thread safety. Such platforms should provide an API for swapping out
+ * the atomic spin lock with an appropriate lock provided by the users operating
+ * system.
+ */
+class atomic_spin_lock : public hal::pollable_lock
+{
+public:
+  /**
+   * @brief Construct a new atomic spin lock object
+   *
+   */
+  atomic_spin_lock() = default;
+  ~atomic_spin_lock() = default;
+
+private:
+  void os_lock() override;
+  void os_unlock() override;
+  bool os_try_lock() override;
+
+  std::atomic_flag m_flag = ATOMIC_FLAG_INIT;
+};
+
+/**
+ * @brief Same as hal::atomic_spin_lock but supports timed_lock apis
+ *
+ * All of the dubious usages of hal::atomic_spin_lock follow with this lock as
+ * well. In general, do not use this in production. Use the appropriate thread
+ * safe lock for your operating system.
+ */
+class timed_atomic_spin_lock : public hal::timed_lock
+{
+public:
+  /**
+   * @brief Construct a new timed atomic spin lock object
+   *
+   * @param p_steady_clock - steady clock used to time the try_lock_for api.
+   */
+  timed_atomic_spin_lock(hal::steady_clock& p_steady_clock)
+    : m_steady_clock(&p_steady_clock)
+  {
+  }
+
+  ~timed_atomic_spin_lock() = default;
+
+private:
+  void os_lock() override;
+  void os_unlock() override;
+  bool os_try_lock() override;
+  bool os_try_lock_for(hal::time_duration p_poll_time) override;
+
+  hal::steady_clock* m_steady_clock;
+  atomic_spin_lock m_atomic_spin_lock;
+};
+}  // namespace hal::soft

--- a/include/libhal-util/bit_bang_i2c.hpp
+++ b/include/libhal-util/bit_bang_i2c.hpp
@@ -1,0 +1,201 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <libhal/i2c.hpp>
+#include <libhal/output_pin.hpp>
+#include <libhal/steady_clock.hpp>
+#include <libhal/units.hpp>
+
+namespace hal {
+/**
+ * @brief A bit bang implementation for i2c.
+ *
+ * This implementation of i2c only needs 2 hal::output_pins and a steady_clock
+ * to work. It does not support multi-controller but we intend to support it in
+ * the future. the data transfer rate for bit-bang is a best-effort
+ * implementation meaning it will almost always run at a frequency which is less
+ * then the request one but, never faster. The maximum achievable clock rate for
+ * the lpc4078 is about 180kHz. Interrupts disrupt this controller because the
+ * transfer is a blocking operation which means an interrupt may come in the
+ * middle of a transaction and may leave a transaction hanging which some
+ * peripherals may not support.
+ */
+class bit_bang_i2c : public i2c
+{
+public:
+  struct pins
+  {
+    output_pin* sda;
+    output_pin* scl;
+  };
+
+  /**
+   * @brief Construct a new i2c bit bang object
+   *
+   * @param p_pins named structure that contains pointers to the scl and sda to
+   * be used inside of the driver
+   * @param p_steady_clock the steady clock that will be used for timing the sda
+   * and scl lines. This should have a higher frequency then the i2c frequency
+   * that this device will be configured to.
+   * @param p_duty_cycle the clock duty cycle. Valid inputs are between 0.3 to
+   * 0.7. Outside of this range and the bit-bang i2c may lock up due to the
+   * shortness of the pulse duration.
+   * @param p_settings the initial settings of the i2c bus
+   *
+   * @throws hal::operation_not_supported if p_duty_cycle is below 0.3f or above
+   * 0.7f.
+   * @throws hal::operation_not_supported via driver_configure which may throw
+   * an exception if the operating speed is higher than the steady clock's
+   * frequency.
+   */
+  bit_bang_i2c(pins const& p_pins,
+               steady_clock& p_steady_clock,
+               float const p_duty_cycle = 0.5f,
+               hal::i2c::settings const& p_settings = {});
+
+private:
+  void driver_configure(settings const& p_settings) override;
+
+  virtual void driver_transaction(
+    hal::byte p_address,
+    std::span<hal::byte const> p_data_out,
+    std::span<hal::byte> p_data_in,
+    function_ref<hal::timeout_function> p_timeout) override;
+
+  /**
+   * @brief This function will send the start condition it will also pull the
+   * pins high before sending the start condition
+   */
+  void send_start_condition();
+
+  /**
+   * @brief This function will send the stop condition while also making sure
+   * the sda pin is pulled low before sending the stop condition
+   */
+  void send_stop_condition();
+
+  /**
+   * @brief This function will go through the steps of writing the address
+   * of the peripheral the controller wishes to speak to while also ensuring the
+   * data written is acknowledged
+   *
+   * @param p_address The address of the peripheral, configured with the
+   * read/write bit already that the controller is requesting to talk to
+   * @param p_timeout A timeout function which is primarily used for clock
+   * stretching to ensure the peripheral doesn't hold the line too long
+   *
+   * @throws hal::no_such_device when the address written to the bus was not
+   * acknowledged
+   */
+  void write_address(hal::byte p_address,
+                     function_ref<hal::timeout_function> p_timeout);
+
+  /**
+   * @brief This function will write the entire contents of the span out to the
+   * bus while making sure all data gets acknowledged
+   *
+   * @param p_data_out This is a span of bytes which will be written to the bus
+   * @param p_timeout A timeout function which is primarily used for clock
+   * stretching to ensure the peripheral doesn't hold the line too long
+   *
+   * @throws hal::io_error when the data written to the bus was not
+   * acknowledged
+   */
+  void write(std::span<hal::byte const> p_data_out,
+             function_ref<hal::timeout_function> p_timeout);
+
+  /**
+   * @brief This function will handle writing a singular byte each call while
+   * also retrieving the acknowledge bits
+   *
+   * @param p_byte_to_write This is the byte that will be written to the bus
+   * @param p_timeout A timeout function which is primarily used for clock
+   * stretching to ensure the peripheral doesn't hold the line too long
+   *
+   * @return bool true when the byte written was ack'd and false when it was
+   * nack'd
+   */
+  bool write_byte(hal::byte p_byte_to_write,
+                  function_ref<hal::timeout_function> p_timeout);
+
+  /**
+   * @brief This function will write a single bit at a time, dealing with
+   * simulating the clock and the clock stretching feature
+   *
+   * @param p_bit_to_write The bit which will be written on the bus
+   * @param p_timeout A timeout function which is primarily used for clock
+   * stretching to ensure the peripheral doesn't hold the line too long
+   */
+  void write_bit(hal::byte p_bit_to_write,
+                 function_ref<hal::timeout_function> p_timeout);
+
+  /**
+   * @brief This function will read in as many bytes as allocated inside of the
+   * span while also ACKing or NACKing the data
+   *
+   * @param p_data_in A span which will be filled with the bytes that will be
+   * read from the bus
+   * @param p_timeout A timeout function which is primarily used for clock
+   * stretching to ensure the peripheral doesn't hold the line too long
+   */
+  void read(std::span<hal::byte> p_data_in,
+            function_ref<hal::timeout_function> p_timeout);
+
+  /**
+   * @brief This function is responsible for reading a byte at a time off the
+   * bus and also creating the byte from bits
+   *
+   * @return hal::byte the byte that has been read off of the bus
+   */
+  hal::byte read_byte();
+
+  /**
+   * @brief This function is responsible for reading a single bit at a time. It
+   * will manage the clock and will release the sda pin (allow it to be pulled
+   * high) every time it is called
+   *
+   * @return hal::byte which will house the single bit read from the bus
+   */
+  hal::byte read_bit();
+
+  /// @brief An output pin which is the i2c scl pin
+  hal::output_pin* m_scl;
+
+  /// @brief An output pin which is the i2c sda pin
+  hal::output_pin* m_sda;
+
+  /// @brief A steady_clock provides a mechanism to delay the clock pulses of
+  /// the scl line.
+  hal::steady_clock* m_clock;
+
+  /// @brief The time that scl will be held high for
+  std::uint64_t m_scl_high_ticks;
+
+  /// @brief The time that scl will be held low for
+  std::uint64_t m_scl_low_ticks;
+
+  /// @brief This is used to preserve the duty cycle that is passed in through
+  /// the constructor and be used in the driver_configure function
+  float m_duty_cycle;
+};
+}  // namespace hal
+
+namespace hal {
+// This is here for backwards compatibility.
+// We made a mistake on the first review and accidentally put bit_bang_i2c in
+// the hal namespace.
+using hal::soft::bit_bang_i2c;
+}  // namespace hal

--- a/include/libhal-util/bit_bang_spi.hpp
+++ b/include/libhal-util/bit_bang_spi.hpp
@@ -1,0 +1,127 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <libhal/input_pin.hpp>
+#include <libhal/output_pin.hpp>
+#include <libhal/spi.hpp>
+#include <libhal/steady_clock.hpp>
+
+namespace hal::soft {
+/**
+ * @brief A bit bang implementation for spi.
+ *
+ * This implementation of spi only needs 2 hal::output_pins for sck and copi, a
+ * hal::input_pin for cipo, and a steady_clock to work.
+ */
+class bit_bang_spi : public spi
+{
+public:
+  struct pins
+  {
+    output_pin* sck;
+    output_pin* copi;
+    input_pin* cipo;
+  };
+
+  /// Adds or removes delays in the read/write cycle
+  enum class delay_mode
+  {
+    /// Calculates the delay time using the clock_rate from the provided
+    /// settings when constructing the bit_bang_spi object
+    with,
+    /// Omits delays between reading/writing to get the fastest speed possible
+    without
+  };
+
+  /**
+   * @brief Construct a new bit bang spi object
+   *
+   * @param p_pins named structure that contains pointers to the sck, copi, and
+   * cipo to be used inside of the driver
+   * @param p_steady_clock the steady clock that will be used for timing the sck
+   * line.
+   * @param p_settings the initial settings of the spi bus
+   * @param p_delay_mode adds or removes delays in the read/write cycle
+   */
+  bit_bang_spi(pins const& p_pins,
+               steady_clock& p_steady_clock,
+               settings const& p_settings = {},
+               delay_mode p_delay_mode = delay_mode::with);
+
+private:
+  void driver_configure(settings const& p_settings) override;
+
+  void driver_transfer(std::span<hal::byte const> p_data_out,
+                       std::span<hal::byte> p_data_in,
+                       hal::byte p_filler) override;
+
+  /**
+   * @brief This function will handle writing a single byte to spi copi line
+   *
+   * @param p_byte_to_write This is the byte that will be written
+   */
+  hal::byte transfer_byte(hal::byte p_byte_to_write);
+
+  /**
+   * @brief This function will handle writing a single byte to spi copi line
+   * without using delays between reading and writing
+   *
+   * @param p_byte_to_write This is the byte that will be written
+   */
+  hal::byte transfer_byte_without_delay(hal::byte p_byte_to_write);
+
+  /**
+   * @brief This function will handle writing a single bit to the spi copi line
+   *
+   * @param p_bit_to_write This is the bit that will be written
+   */
+  bool transfer_bit(bool p_bit_to_write);
+
+  /**
+   * @brief This function will handle writing a single bit to the spi copi line
+   * without using delays between reading and writing
+   *
+   * @param p_bit_to_write This is the bit that will be written
+   */
+  bool transfer_bit_without_delay(bool p_bit_to_write);
+
+  /// @brief An output pin which is the spi sck pin
+  hal::output_pin* m_sck;
+
+  /// @brief An output pin which is the spi copi pin
+  hal::output_pin* m_copi;
+
+  /// @brief An input pin which is the spi cipo pin
+  hal::input_pin* m_cipo;
+
+  /// @brief A steady_clock provides a mechanism to delay the clock pulses of
+  /// the sck line.
+  hal::steady_clock* m_clock;
+
+  /// @brief State of the sck line when inactive
+  bool m_polarity;
+
+  /// @brief Phase of the sck line dictates when to read/write bits
+  bool m_phase;
+
+  /// @brief Time of a full read/write cycle, used in delay_mode::with
+  hal::time_duration m_cycle_duration;
+
+  /// @brief Configuration for using delays or not
+  delay_mode m_delay_mode;
+};
+
+}  // namespace hal::soft

--- a/include/libhal-util/buffered_can.hpp
+++ b/include/libhal-util/buffered_can.hpp
@@ -14,10 +14,14 @@
 
 #pragma once
 
+#if 0
+#include <cmath>
 #include <cstdlib>
 #include <optional>
 
-#include <libhal/can.hpp>
+#include <libhal/buffered_can.hpp>
+
+#include "math.hpp"
 
 /**
  * @defgroup CAN_Utilities CAN Utilities
@@ -25,6 +29,20 @@
  */
 
 namespace hal {
+/**
+ * @ingroup CAN_Utilities
+ * @brief Compares two CAN bus settings.
+ *
+ * @param p_lhs CAN bus settings
+ * @param p_rhs A CAN bus setting to compare against another
+ * @return A boolean if they are the same or not.
+ */
+[[nodiscard]] constexpr auto operator==(can::settings const& p_lhs,
+                                        can::settings const& p_rhs)
+{
+  return equals(p_lhs.baud_rate, p_rhs.baud_rate);
+}
+
 /**
  * @brief Generic settings for a can peripheral
  * @ingroup CAN_Utilities
@@ -190,4 +208,22 @@ struct can_bus_divider_t
 
   return timing;
 }
+
+/**
+ * @ingroup CAN_Utilities
+ * @brief Compares two CAN message states.
+ *
+ * @param p_lhs A CAN message.
+ * @param p_rhs A CAN message.
+ * @return A boolean if they are the same or not.
+ */
+[[nodiscard]] constexpr auto operator==(can::message_t const& p_lhs,
+                                        can::message_t const& p_rhs)
+{
+  bool payload_equal = p_lhs.payload == p_rhs.payload;
+  return payload_equal && p_lhs.id == p_rhs.id &&
+         p_lhs.length == p_rhs.length &&
+         p_lhs.is_remote_request == p_rhs.is_remote_request;
+}
 }  // namespace hal
+#endif

--- a/include/libhal-util/i2c.hpp
+++ b/include/libhal-util/i2c.hpp
@@ -14,14 +14,11 @@
 
 #pragma once
 
-#include <functional>
-
 #include <libhal/error.hpp>
 #include <libhal/i2c.hpp>
 #include <libhal/units.hpp>
 
 #include "enum.hpp"
-#include "math.hpp"
 
 /**
  * @defgroup I2CUtils I2C Utils
@@ -29,35 +26,23 @@
 namespace hal {
 /**
  * @ingroup I2CUtils
- * @brief Compares two I2C bus states.
- *
- * @param p_lhs A I2C bus.
- * @param p_rhs A I2C bus.
- * @return A boolean if they are the same or not.
- */
-[[nodiscard]] constexpr auto operator==(i2c::settings const& p_lhs,
-                                        i2c::settings const& p_rhs)
-{
-  return equals(p_lhs.clock_rate, p_rhs.clock_rate);
-}
-
-/**
- * @ingroup I2CUtils
- * @brief write data to a target device on the i2c bus
+ * @deprecated use APIs that do not use timeouts
+ * @brief write data to a target device on the i2c bus with a timeout
+ * @deprecated Prefer to use the write API that does not require a timeout.
  *
  * Shorthand for writing i2c.transfer(...) for write only operations
  *
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
- * @param p_timeout - amount of time to execute the transaction
+ * @param auto - [deprecated don't use]
  */
 inline void write(i2c& p_i2c,
                   hal::byte p_address,
                   std::span<hal::byte const> p_data_out,
-                  timeout auto p_timeout)
+                  timeout auto)
 {
-  p_i2c.transaction(p_address, p_data_out, std::span<hal::byte>{}, p_timeout);
+  p_i2c.transaction(p_address, p_data_out, std::span<hal::byte>{});
 }
 
 /**
@@ -80,6 +65,7 @@ inline void write(i2c& p_i2c,
 
 /**
  * @ingroup I2CUtils
+ * @deprecated use APIs that do not use timeouts
  * @brief read bytes from target device on i2c bus
  *
  * Shorthand for writing i2c.transfer(...) for read only operations
@@ -87,18 +73,19 @@ inline void write(i2c& p_i2c,
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_in - buffer to read bytes into from target device
- * @param p_timeout - amount of time to execute the transaction
+ * @param auto - [deprecated don't use]
  */
 inline void read(i2c& p_i2c,
                  hal::byte p_address,
                  std::span<hal::byte> p_data_in,
-                 timeout auto p_timeout)
+                 timeout auto)
 {
-  p_i2c.transaction(p_address, std::span<hal::byte>{}, p_data_in, p_timeout);
+  p_i2c.transaction(p_address, std::span<hal::byte>{}, p_data_in);
 }
 
 /**
  * @ingroup I2CUtils
+ * @deprecated use APIs that do not use timeouts
  * @brief read bytes from target device on i2c bus
  *
  * Shorthand for writing i2c.transfer(...) for read only operations, but never
@@ -117,6 +104,7 @@ inline void read(i2c& p_i2c,
 
 /**
  * @ingroup I2CUtils
+ * @deprecated use APIs that do not use timeouts
  * @brief return array of read bytes from target device on i2c bus
  *
  * Eliminates the need to create a buffer and pass it into the read function.
@@ -124,17 +112,17 @@ inline void read(i2c& p_i2c,
  * @tparam bytes_to_read - number of bytes to read
  * @param p_i2c - i2c driver
  * @param p_address - target address
- * @param p_timeout - amount of time to execute the transaction
+ * @param auto - [deprecated don't use]
  * @return std::array<hal::byte, bytes_to_read> - array of bytes from target
  * device
  */
 template<size_t bytes_to_read>
 [[nodiscard]] std::array<hal::byte, bytes_to_read> read(i2c& p_i2c,
                                                         hal::byte p_address,
-                                                        timeout auto p_timeout)
+                                                        timeout auto)
 {
   std::array<hal::byte, bytes_to_read> buffer;
-  read(p_i2c, p_address, buffer, p_timeout);
+  read(p_i2c, p_address, buffer);
   return buffer;
 }
 
@@ -143,24 +131,25 @@ template<size_t bytes_to_read>
  * @brief return array of read bytes from target device on i2c bus
  *
  * Eliminates the need to create a buffer and pass it into the read function.
- * This operation will never time out and should only be used with devices that
- * never perform clock stretching.
  *
  * @tparam bytes_to_read - number of bytes to read
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @return std::array<hal::byte, bytes_to_read> - array of bytes from target
- * device.
+ * device
  */
 template<size_t bytes_to_read>
 [[nodiscard]] std::array<hal::byte, bytes_to_read> read(i2c& p_i2c,
                                                         hal::byte p_address)
 {
-  return read<bytes_to_read>(p_i2c, p_address, hal::never_timeout());
+  std::array<hal::byte, bytes_to_read> buffer;
+  read(p_i2c, p_address, buffer);
+  return buffer;
 }
 
 /**
  * @ingroup I2CUtils
+ * @deprecated use APIs that do not use timeouts
  * @brief write and then read bytes from target device on i2c bus
  *
  * This API simply calls transaction. This API is here for consistency across
@@ -170,15 +159,15 @@ template<size_t bytes_to_read>
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
  * @param p_data_in - buffer to read bytes into from target device
- * @param p_timeout - amount of time to execute the transaction
+ * @param auto - amount of time to execute the transaction
  */
 inline void write_then_read(i2c& p_i2c,
                             hal::byte p_address,
                             std::span<hal::byte const> p_data_out,
                             std::span<hal::byte> p_data_in,
-                            timeout auto p_timeout = hal::never_timeout())
+                            timeout auto)
 {
-  p_i2c.transaction(p_address, p_data_out, p_data_in, p_timeout);
+  p_i2c.transaction(p_address, p_data_out, p_data_in);
 }
 
 /**
@@ -206,6 +195,7 @@ inline void write_then_read(i2c& p_i2c,
 
 /**
  * @ingroup I2CUtils
+ * @deprecated use APIs that do not use timeouts
  * @brief write and then return an array of read bytes from target device on i2c
  * bus
  *
@@ -215,7 +205,7 @@ inline void write_then_read(i2c& p_i2c,
  * @param p_i2c - i2c driver
  * @param p_address - target address
  * @param p_data_out - buffer of bytes to write to the target device
- * @param p_timeout - amount of time to execute the transaction
+ * @param auto - [deprecated use the APIs without timeout parameters]
  * @return std::array<hal::byte, bytes_to_read> - array of bytes from target
  * device.
  */
@@ -224,10 +214,10 @@ template<size_t bytes_to_read>
   i2c& p_i2c,
   hal::byte p_address,
   std::span<hal::byte const> p_data_out,
-  timeout auto p_timeout)
+  timeout auto)
 {
   std::array<hal::byte, bytes_to_read> buffer;
-  write_then_read(p_i2c, p_address, p_data_out, buffer, p_timeout);
+  write_then_read(p_i2c, p_address, p_data_out, buffer);
   return buffer;
 }
 
@@ -250,8 +240,9 @@ template<size_t bytes_to_read>
   hal::byte p_address,
   std::span<hal::byte const> p_data_out)
 {
-  return write_then_read<bytes_to_read>(
-    p_i2c, p_address, p_data_out, hal::never_timeout());
+  std::array<hal::byte, bytes_to_read> buffer;
+  write_then_read(p_i2c, p_address, p_data_out, buffer);
+  return buffer;
 }
 
 /**
@@ -310,6 +301,7 @@ enum class i2c_operation
   hal::byte p_address,
   i2c_operation p_operation) noexcept
 {
+  // TODO(#36): remove noexcept from this function on libhal's 5.0.0 API break
   hal::byte v8bit_address = static_cast<hal::byte>(p_address << 1);
   v8bit_address |= hal::value(p_operation);
   return v8bit_address;

--- a/include/libhal-util/i2c_minimum_speed.hpp
+++ b/include/libhal-util/i2c_minimum_speed.hpp
@@ -1,0 +1,58 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <libhal/i2c.hpp>
+
+namespace hal {
+
+// TODO(#38) Remove on libhal 5.0.0
+/**
+ * @brief A i2c wrapper to ensure that the lowest i2c device frequency is used.
+ * @deprecated Do not use this class as it is a trap. This wrapper cannot ensure
+ * that the i2c clock speed is the minimum possible for all devices on the bus
+ * without knowledge about the system before hand.
+ */
+class minimum_speed_i2c : public hal::i2c
+{
+public:
+  constexpr static auto default_max_speed = 2'000'000;
+  /**
+   * @brief Create minimum_speed_i2c object.
+   *
+   * @param p_i2c - i2c object that the device will use
+   * @param p_frequency - the maximum starting frequency the device can use
+   */
+  minimum_speed_i2c(hal::i2c& p_i2c, hertz p_frequency = default_max_speed);
+
+private:
+  /**
+   * @brief Pass through configuration function from this class to the passed
+   * i2c driver.
+   *
+   * @param p_new_setting - settings to be set
+   */
+  void driver_configure(settings const& p_new_setting) override;
+
+  void driver_transaction(
+    hal::byte p_address,
+    std::span<hal::byte const> p_data_out,
+    std::span<hal::byte> p_data_in,
+    hal::function_ref<hal::timeout_function> p_timeout) override;
+
+  hal::i2c* m_i2c;
+  hertz m_lowest_seen_frequency;
+};
+}  // namespace hal

--- a/include/libhal-util/serial.hpp
+++ b/include/libhal-util/serial.hpp
@@ -24,8 +24,6 @@
 #include <libhal/units.hpp>
 
 #include "as_bytes.hpp"
-#include "comparison.hpp"
-#include "math.hpp"
 
 /**
  * @defgroup Serial Serial
@@ -33,20 +31,7 @@
  */
 
 namespace hal {
-/**
- * @ingroup Serial
- * @brief Compares two serial objects via their settings.
- *
- * @param p_lhs A serial object
- * @param p_rhs A serial object
- * @return A boolean if they are the same or not.
- */
-[[nodiscard]] constexpr auto operator==(serial::settings const& p_lhs,
-                                        serial::settings const& p_rhs)
-{
-  return equals(p_lhs.baud_rate, p_rhs.baud_rate) &&
-         p_lhs.parity == p_rhs.parity && p_lhs.stop == p_rhs.stop;
-}
+// TODO(#38): Remove on release of libhal 5.0.0
 /**
  * @ingroup Serial
  * @brief Write bytes to a serial port

--- a/tests/i2c.test.cpp
+++ b/tests/i2c.test.cpp
@@ -101,7 +101,8 @@ void i2c_util_test()
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % nullptr == i2c.m_in.data());
     expect(that % 0 == i2c.m_in.size());
-    expect(that % true == test_timeout.was_called);
+    // Verify: timeout will be ignored from libhal 4.5.0 and beyond
+    expect(that % false == test_timeout.was_called);
   };
 
   "[failure] write"_test = []() {
@@ -140,7 +141,8 @@ void i2c_util_test()
     expect(that % expected_buffer.size() == i2c.m_in.size());
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
-    expect(that % true == test_timeout.was_called);
+    // Verify: timeout will be ignored from libhal 4.5.0 and beyond
+    expect(that % false == test_timeout.was_called);
   };
 
   "[failure] read"_test = []() {
@@ -180,7 +182,8 @@ void i2c_util_test()
     expect(std::equal(expected.begin(), expected.end(), actual.begin()));
     expect(that % nullptr == i2c.m_out.data());
     expect(that % 0 == i2c.m_out.size());
-    expect(that % true == test_timeout.was_called);
+    // Verify: timeout will be ignored from libhal 4.5.0 and beyond
+    expect(that % false == test_timeout.was_called);
   };
 
   "[failure] read<Length>"_test = []() {
@@ -221,7 +224,8 @@ void i2c_util_test()
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(that % expected_buffer.data() == i2c.m_in.data());
     expect(that % expected_buffer.size() == i2c.m_in.size());
-    expect(that % true == test_timeout.was_called);
+    // Verify: timeout will be ignored from libhal 4.5.0 and beyond
+    expect(that % false == test_timeout.was_called);
   };
 
   "[failure] write_then_read"_test = []() {
@@ -268,7 +272,8 @@ void i2c_util_test()
     expect(that % expected_payload.data() == i2c.m_out.data());
     expect(that % expected_payload.size() == i2c.m_out.size());
     expect(std::equal(expected.begin(), expected.end(), actual.begin()));
-    expect(that % true == test_timeout.was_called);
+    // Verify: timeout will be ignored from libhal 4.5.0 and beyond
+    expect(that % false == test_timeout.was_called);
   };
 
   "[failure] write_then_read<Length>"_test = []() {


### PR DESCRIPTION
- API break in libhal-util because libhal now has its own comparison operator added to each settings, which makes the operator comparisons redundant and ambiguous
- I2C utilities have their timeout inputs ignored as per the new direction of libhal code for i2c.