### PR TITLE
:bug: Fix protocol & timing issues w/ bit_bang_i2c

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,2 @@
-If:
-  PathMatch: demos/.*
-  CompileFlags:
-    CompilationDatabase: demos
-Else:
-  CompileFlags:
-    CompilationDatabase: .
+CompileFlags:
+  CompilationDatabase: .

--- a/tests/bit_bang_i2c.test.cpp
+++ b/tests/bit_bang_i2c.test.cpp
@@ -14,6 +14,8 @@
 
 #include <libhal-util/bit_bang_i2c.hpp>
 
+#include <numeric>
+
 #include <libhal-util/mock/input_pin.hpp>
 #include <libhal-util/mock/output_pin.hpp>
 #include <libhal-util/mock/steady_clock.hpp>
@@ -35,7 +37,8 @@ boost::ut::suite<"bit_bang_i2c"> bit_bang_i2c_test = [] {
     hal::mock_steady_clock steady_clock;
 
     steady_clock.set_frequency(1.0_MHz);
-    auto const uptime_set = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    std::vector<hal::u64> uptime_set(4098);
+    std::iota(uptime_set.begin(), uptime_set.end(), 0);
     std::queue<hal::u64> uptimes(uptime_set.begin(), uptime_set.end());
     steady_clock.set_uptimes(uptimes);
 


### PR DESCRIPTION
The state of the output pins provided to `hal::bit_bang_i2c` can be in
any state, meaning that the i2c bus may be in a state that will not work
initially. In order to initialize the bus to a known state,
`hal::probe(*this, 0x00)` is called twice.