### PR TITLE
:wrench: Generate compile_commands.json with conan install

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -67,6 +67,11 @@ class libhal_util_conan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
+    def generate(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build(target="copy_compile_commands")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
Allows use of clangd via a compile commands JSON without fully building entire project